### PR TITLE
feat: add controllable Compose banner state

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A lifecycle-aware banner wrapper for the
 releases `AdView`, tracks load state, and forwards banner callbacks on the main thread.
 
 > [!IMPORTANT]
-> Version 0.5.1 uses GMA Next-Gen SDK 1.3.1. It requires Android API 24+, `compileSdk` 35+,
+> Version 0.5.2 uses GMA Next-Gen SDK 1.3.1. It requires Android API 24+, `compileSdk` 35+,
 > Kotlin 1.9+ for Kotlin apps, and completed SDK initialization before the first ad request.
 
 ## Install
@@ -18,7 +18,7 @@ repositories {
     mavenCentral()
 }
 
-def version = '0.5.1'
+def version = '0.5.2'
 
 dependencies {
     // Views
@@ -102,17 +102,26 @@ adaptive banners from the available Compose width and destroys the underlying vi
 composition. It is built against Compose UI 1.10.6 to retain Kotlin 1.9 consumer compatibility:
 
 ```kotlin
+val state = rememberAdContainerState()
+
 AdaptiveAdContainer(
     adUnitId = BANNER_AD_UNIT_ID,
+    state = state,
     modifier = Modifier.fillMaxWidth()
 )
+
+TextButton(onClick = state::reload) {
+    Text("Reload")
+}
 ```
 
 Use `AdContainer` when supplying a fixed size or customized `BannerAdRequest`. Remember customized
 requests that should remain stable across recomposition; a different request instance reloads the
-banner. Initialize Next-Gen before placing either composable in the composition. Optional load
-lambdas report request starts, success, and failure; configure event and refresh callbacks on the
-loaded `BannerAd`.
+banner. `AdContainerState.loadState` reports idle, loading, loaded, and failed states. State-aware
+overloads also accept `AdLoadCallback<BannerAd>`, `BannerAdEventCallback`, and
+`BannerAdRefreshCallback`. `reload()` calls `loadAdView()` on the existing container; Compose does not
+recreate it. Initialize Next-Gen before placing either composable in composition; Compose handles
+cleanup when it leaves.
 
 ## Configuration
 
@@ -155,10 +164,11 @@ Both overloads accept `parentHasListView` and `showOnCondition` options. Setting
 Next-Gen separates banner callbacks by purpose:
 
 - `setAdLoadCallback()` — initial load success or failure
-- `setAdEventCallback()` — click, impression, paid, and full-screen events
+- `setAdEventCallback()` — click, impression, paid, app, and full-screen events
 - `setAdRefreshCallback()` — automatic refresh success or failure
 
-AdContainerView delivers callbacks registered through these methods on the main thread.
+AdContainerView delivers callbacks registered through these methods on the main thread. Pass `null`
+to clear a callback.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ A lifecycle-aware banner wrapper for the
 releases `AdView`, tracks load state, and forwards banner callbacks on the main thread.
 
 > [!IMPORTANT]
-> Version 0.5.2 uses GMA Next-Gen SDK 1.3.1. It requires Android API 24+, `compileSdk` 35+,
-> Kotlin 1.9+ for Kotlin apps, and completed SDK initialization before the first ad request.
+> The 0.5.x release line uses GMA Next-Gen SDK 1.3.1 and requires Android API 24+,
+> `compileSdk` 35+, Kotlin 1.9+ for Kotlin apps, and completed SDK initialization before the first
+> ad request.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -121,8 +121,9 @@ requests that should remain stable across recomposition; a different request ins
 banner. `AdContainerState.loadState` reports idle, loading, loaded, and failed states. State-aware
 overloads also accept `AdLoadCallback<BannerAd>`, `BannerAdEventCallback`, and
 `BannerAdRefreshCallback`. `reload()` calls `loadAdView()` on the existing container; Compose does not
-recreate it. Initialize Next-Gen before placing either composable in composition; Compose handles
-cleanup when it leaves.
+recreate it. Loading and failed states describe the latest request; a previous banner may remain
+visible. Initialize Next-Gen before placing either composable in composition; Compose handles cleanup
+when it leaves.
 
 ## Configuration
 

--- a/acv-compose/src/main/java/com/lazygeniouz/acv/compose/AdContainer.kt
+++ b/acv-compose/src/main/java/com/lazygeniouz/acv/compose/AdContainer.kt
@@ -1,71 +1,18 @@
+@file:JvmMultifileClass
+@file:JvmName("AdContainerKt")
+
 package com.lazygeniouz.acv.compose
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.platform.LocalWindowInfo
-import androidx.compose.ui.viewinterop.AndroidView
 import com.google.android.libraries.ads.mobile.sdk.banner.AdSize
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRefreshCallback
 import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRequest
 import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
 import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
-import com.lazygeniouz.acv.AdContainerView
-
-/**
- * Loads and displays a large anchored adaptive banner using the available Compose width.
- * The banner reloads when its calculated size or [adUnitId] changes.
- *
- * @param adUnitId the banner ad unit ID.
- * @param modifier the modifier applied to the full-width banner container.
- * @param onAdLoadStarted called on the main thread immediately before a new request attempt.
- * @param onAdLoaded called with the loaded banner on the main thread.
- * @param onAdFailedToLoad called with the load error on the main thread.
- */
-@Composable
-fun AdaptiveAdContainer(
-    adUnitId: String,
-    modifier: Modifier = Modifier,
-    onAdLoadStarted: () -> Unit = {},
-    onAdLoaded: (BannerAd) -> Unit = {},
-    onAdFailedToLoad: (LoadAdError) -> Unit = {}
-) {
-    val context = LocalContext.current
-    val density = LocalDensity.current
-    val windowInfo = LocalWindowInfo.current
-
-    BoxWithConstraints(modifier = modifier) {
-        val windowSize = windowInfo.containerSize
-        val windowWidthDp = with(density) {
-            windowSize.width.toDp().value.toInt()
-        }.coerceAtLeast(1)
-        val availableWidthDp = maxWidth.value
-            .takeIf { it.isFinite() && it > 0f }
-            ?.toInt()
-            ?: windowWidthDp
-        val adSize = remember(context, availableWidthDp, windowSize, density) {
-            AdSize.getLargeAnchoredAdaptiveBannerAdSize(context, availableWidthDp)
-        }
-
-        AdContainer(
-            adUnitId = adUnitId,
-            adSize = adSize,
-            modifier = Modifier.fillMaxWidth(),
-            onAdLoadStarted = onAdLoadStarted,
-            onAdLoaded = onAdLoaded,
-            onAdFailedToLoad = onAdFailedToLoad
-        )
-    }
-}
 
 /**
  * Loads and displays a banner for the supplied ad unit and fixed or precomputed adaptive size.
@@ -87,15 +34,47 @@ fun AdContainer(
     onAdLoaded: (BannerAd) -> Unit = {},
     onAdFailedToLoad: (LoadAdError) -> Unit = {}
 ) {
-    val adRequest = remember(adUnitId, adSize) {
-        BannerAdRequest.Builder(adUnitId, adSize).build()
-    }
-    AdContainer(
-        adRequest = adRequest,
+    AdContainerHost(
+        adRequest = rememberBannerAdRequest(adUnitId, adSize),
+        state = rememberAdContainerState(),
         modifier = modifier,
         onAdLoadStarted = onAdLoadStarted,
-        onAdLoaded = onAdLoaded,
-        onAdFailedToLoad = onAdFailedToLoad
+        adLoadCallback = lambdaAdLoadCallback(onAdLoaded, onAdFailedToLoad),
+        adEventCallback = null,
+        adRefreshCallback = null
+    )
+}
+
+/**
+ * Loads and displays a controllable banner for the supplied ad unit and fixed or precomputed
+ * adaptive size. Call [AdContainerState.reload] to submit the same request again.
+ *
+ * @param adUnitId the banner ad unit ID.
+ * @param adSize the fixed or precomputed adaptive banner size.
+ * @param state the observable state and reload control for this container.
+ * @param modifier the modifier applied to the banner container.
+ * @param adLoadCallback receives the initial banner load result.
+ * @param adEventCallback receives click, impression, paid, app, and full-screen events.
+ * @param adRefreshCallback receives automatic banner refresh results.
+ */
+@Composable
+fun AdContainer(
+    adUnitId: String,
+    adSize: AdSize,
+    state: AdContainerState,
+    modifier: Modifier = Modifier,
+    adLoadCallback: AdLoadCallback<BannerAd>? = null,
+    adEventCallback: BannerAdEventCallback? = null,
+    adRefreshCallback: BannerAdRefreshCallback? = null
+) {
+    AdContainerHost(
+        adRequest = rememberBannerAdRequest(adUnitId, adSize),
+        state = state,
+        modifier = modifier,
+        onAdLoadStarted = {},
+        adLoadCallback = adLoadCallback,
+        adEventCallback = adEventCallback,
+        adRefreshCallback = adRefreshCallback
     )
 }
 
@@ -118,34 +97,60 @@ fun AdContainer(
     onAdLoaded: (BannerAd) -> Unit = {},
     onAdFailedToLoad: (LoadAdError) -> Unit = {}
 ) {
-    val currentOnAdLoadStarted by rememberUpdatedState(onAdLoadStarted)
-    val currentOnAdLoaded by rememberUpdatedState(onAdLoaded)
-    val currentOnAdFailedToLoad by rememberUpdatedState(onAdFailedToLoad)
+    AdContainerHost(
+        adRequest = adRequest,
+        state = rememberAdContainerState(),
+        modifier = modifier,
+        onAdLoadStarted = onAdLoadStarted,
+        adLoadCallback = lambdaAdLoadCallback(onAdLoaded, onAdFailedToLoad),
+        adEventCallback = null,
+        adRefreshCallback = null
+    )
+}
 
-    if (LocalInspectionMode.current) {
-        Box(modifier = modifier)
-        return
+/**
+ * Loads and displays a controllable banner for a customized [BannerAdRequest]. Remember requests
+ * that should remain stable across recomposition; a different request instance reloads the banner.
+ * Call [AdContainerState.reload] to submit the current request again.
+ *
+ * @param adRequest the fully configured banner request.
+ * @param state the observable state and reload control for this container.
+ * @param modifier the modifier applied to the banner container.
+ * @param adLoadCallback receives the initial banner load result.
+ * @param adEventCallback receives click, impression, paid, app, and full-screen events.
+ * @param adRefreshCallback receives automatic banner refresh results.
+ */
+@Composable
+fun AdContainer(
+    adRequest: BannerAdRequest,
+    state: AdContainerState,
+    modifier: Modifier = Modifier,
+    adLoadCallback: AdLoadCallback<BannerAd>? = null,
+    adEventCallback: BannerAdEventCallback? = null,
+    adRefreshCallback: BannerAdRefreshCallback? = null
+) {
+    AdContainerHost(
+        adRequest = adRequest,
+        state = state,
+        modifier = modifier,
+        onAdLoadStarted = {},
+        adLoadCallback = adLoadCallback,
+        adEventCallback = adEventCallback,
+        adRefreshCallback = adRefreshCallback
+    )
+}
+
+@Composable
+private fun rememberBannerAdRequest(adUnitId: String, adSize: AdSize): BannerAdRequest =
+    remember(adUnitId, adSize) {
+        BannerAdRequest.Builder(adUnitId, adSize).build()
     }
 
-    key(adRequest) {
-        AndroidView(
-            modifier = modifier,
-            factory = { context ->
-                AdContainerView(context).apply {
-                    setAdLoadCallback(object : AdLoadCallback<BannerAd> {
-                        override fun onAdLoaded(ad: BannerAd) {
-                            currentOnAdLoaded(ad)
-                        }
+private fun lambdaAdLoadCallback(
+    onAdLoaded: (BannerAd) -> Unit,
+    onAdFailedToLoad: (LoadAdError) -> Unit
+): AdLoadCallback<BannerAd> = object : AdLoadCallback<BannerAd> {
+    override fun onAdLoaded(ad: BannerAd) = onAdLoaded(ad)
 
-                        override fun onAdFailedToLoad(adError: LoadAdError) {
-                            currentOnAdFailedToLoad(adError)
-                        }
-                    })
-                    currentOnAdLoadStarted()
-                    loadAdView(adRequest)
-                }
-            },
-            onRelease = AdContainerView::destroyAd
-        )
-    }
+    override fun onAdFailedToLoad(adError: LoadAdError) = onAdFailedToLoad(adError)
 }

--- a/acv-compose/src/main/java/com/lazygeniouz/acv/compose/AdContainerHost.kt
+++ b/acv-compose/src/main/java/com/lazygeniouz/acv/compose/AdContainerHost.kt
@@ -1,0 +1,73 @@
+package com.lazygeniouz.acv.compose
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.viewinterop.AndroidView
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRefreshCallback
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.lazygeniouz.acv.AdContainerView
+
+@Composable
+internal fun AdContainerHost(
+    adRequest: BannerAdRequest,
+    state: AdContainerState,
+    modifier: Modifier,
+    onAdLoadStarted: () -> Unit,
+    adLoadCallback: AdLoadCallback<BannerAd>?,
+    adEventCallback: BannerAdEventCallback?,
+    adRefreshCallback: BannerAdRefreshCallback?
+) {
+    val currentOnAdLoadStarted = rememberUpdatedState(onAdLoadStarted)
+    val currentAdLoadCallback = rememberUpdatedState(adLoadCallback)
+
+    if (LocalInspectionMode.current) {
+        Box(modifier = modifier)
+        return
+    }
+
+    key(state) {
+        AndroidView(
+            modifier = modifier,
+            factory = { context ->
+                AdContainerView(context).also { container ->
+                    container.setAdLoadCallback(object : AdLoadCallback<BannerAd> {
+                        override fun onAdLoaded(ad: BannerAd) {
+                            state.onAdLoaded(container)
+                            currentAdLoadCallback.value?.onAdLoaded(ad)
+                        }
+
+                        override fun onAdFailedToLoad(adError: LoadAdError) {
+                            state.onAdFailedToLoad(container, adError)
+                            currentAdLoadCallback.value?.onAdFailedToLoad(adError)
+                        }
+                    })
+                    container.setAdEventCallback(adEventCallback)
+                    container.setAdRefreshCallback(adRefreshCallback)
+                    state.attach(container, adRequest)
+                    currentOnAdLoadStarted.value()
+                    container.loadAdView(adRequest)
+                }
+            },
+            update = { container ->
+                container.setAdEventCallback(adEventCallback)
+                container.setAdRefreshCallback(adRefreshCallback)
+                if (state.updateRequest(container, adRequest)) {
+                    currentOnAdLoadStarted.value()
+                    container.loadAdView(adRequest)
+                }
+            },
+            onRelease = { container ->
+                container.destroyAd()
+                state.onReleased(container)
+            }
+        )
+    }
+}

--- a/acv-compose/src/main/java/com/lazygeniouz/acv/compose/AdContainerState.kt
+++ b/acv-compose/src/main/java/com/lazygeniouz/acv/compose/AdContainerState.kt
@@ -17,13 +17,13 @@ sealed interface AdContainerLoadState {
     /** No ad container is currently attached to this state. */
     data object Idle : AdContainerLoadState
 
-    /** A banner request is in progress. */
+    /** A banner request is in progress; a previously loaded banner may remain visible. */
     data object Loading : AdContainerLoadState
 
     /** The latest banner request completed successfully. */
     data object Loaded : AdContainerLoadState
 
-    /** The latest banner request failed. */
+    /** The latest banner request failed; a previously loaded banner may remain visible. */
     data class Failed(val error: LoadAdError) : AdContainerLoadState
 }
 

--- a/acv-compose/src/main/java/com/lazygeniouz/acv/compose/AdContainerState.kt
+++ b/acv-compose/src/main/java/com/lazygeniouz/acv/compose/AdContainerState.kt
@@ -1,0 +1,104 @@
+package com.lazygeniouz.acv.compose
+
+import androidx.annotation.MainThread
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.lazygeniouz.acv.AdContainerView
+
+/** The current explicit-load state of a Compose ad container. */
+sealed interface AdContainerLoadState {
+
+    /** No ad container is currently attached to this state. */
+    data object Idle : AdContainerLoadState
+
+    /** A banner request is in progress. */
+    data object Loading : AdContainerLoadState
+
+    /** The latest banner request completed successfully. */
+    data object Loaded : AdContainerLoadState
+
+    /** The latest banner request failed. */
+    data class Failed(val error: LoadAdError) : AdContainerLoadState
+}
+
+/**
+ * Observable load state and reload control for one Compose ad container.
+ *
+ * Use [rememberAdContainerState] in composition. One instance can control only one simultaneously
+ * composed ad container.
+ */
+@Stable
+class AdContainerState {
+
+    /** The current explicit-load state. Automatic refresh results are reported separately. */
+    var loadState: AdContainerLoadState by mutableStateOf(AdContainerLoadState.Idle)
+        private set
+
+    private var attachedContainer: AdContainerView? = null
+    private var attachedRequest: BannerAdRequest? = null
+
+    /** Requests a fresh banner using the currently composed request. Does nothing when detached. */
+    @MainThread
+    fun reload() {
+        val container = attachedContainer ?: return
+        val request = attachedRequest ?: return
+
+        loadState = AdContainerLoadState.Loading
+        container.loadAdView(request)
+    }
+
+    internal fun attach(container: AdContainerView, request: BannerAdRequest) {
+        check(attachedContainer == null || attachedContainer === container) {
+            "AdContainerState cannot be shared by multiple ad containers."
+        }
+        attachedContainer = container
+        attachedRequest = request
+        loadState = AdContainerLoadState.Loading
+    }
+
+    internal fun updateRequest(container: AdContainerView, request: BannerAdRequest): Boolean {
+        if (attachedContainer !== container || attachedRequest === request) return false
+
+        attachedRequest = request
+        loadState = AdContainerLoadState.Loading
+        return true
+    }
+
+    internal fun onAdLoaded(container: AdContainerView) {
+        if (attachedContainer === container) {
+            loadState = if (container.isLoading()) {
+                AdContainerLoadState.Loading
+            } else {
+                AdContainerLoadState.Loaded
+            }
+        }
+    }
+
+    internal fun onAdFailedToLoad(container: AdContainerView, error: LoadAdError) {
+        if (attachedContainer === container) {
+            loadState = if (container.isLoading()) {
+                AdContainerLoadState.Loading
+            } else {
+                AdContainerLoadState.Failed(error)
+            }
+        }
+    }
+
+    internal fun onReleased(container: AdContainerView) {
+        if (attachedContainer === container) {
+            attachedContainer = null
+            attachedRequest = null
+            loadState = AdContainerLoadState.Idle
+        }
+    }
+}
+
+/** Remembers an [AdContainerState] for one Compose ad container. */
+@Composable
+fun rememberAdContainerState(): AdContainerState = remember { AdContainerState() }

--- a/acv-compose/src/main/java/com/lazygeniouz/acv/compose/AdaptiveAdContainer.kt
+++ b/acv-compose/src/main/java/com/lazygeniouz/acv/compose/AdaptiveAdContainer.kt
@@ -110,7 +110,12 @@ private fun AdaptiveAdContainerContent(
             .takeIf { it.isFinite() && it > 0f }
             ?.toInt()
             ?: windowWidthDp
-        val adSize = remember(context, availableWidthDp) {
+        val adSize = remember(
+            context,
+            availableWidthDp,
+            windowSize.height,
+            density.density
+        ) {
             AdSize.getLargeAnchoredAdaptiveBannerAdSize(context, availableWidthDp)
         }
 

--- a/acv-compose/src/main/java/com/lazygeniouz/acv/compose/AdaptiveAdContainer.kt
+++ b/acv-compose/src/main/java/com/lazygeniouz/acv/compose/AdaptiveAdContainer.kt
@@ -1,0 +1,127 @@
+@file:JvmMultifileClass
+@file:JvmName("AdContainerKt")
+
+package com.lazygeniouz.acv.compose
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import com.google.android.libraries.ads.mobile.sdk.banner.AdSize
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRefreshCallback
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+
+/**
+ * Loads and displays a large anchored adaptive banner using the available Compose width.
+ * The banner reloads when its calculated size or [adUnitId] changes.
+ *
+ * @param adUnitId the banner ad unit ID.
+ * @param modifier the modifier applied to the full-width banner container.
+ * @param onAdLoadStarted called on the main thread immediately before a new request attempt.
+ * @param onAdLoaded called with the loaded banner on the main thread.
+ * @param onAdFailedToLoad called with the load error on the main thread.
+ */
+@Composable
+fun AdaptiveAdContainer(
+    adUnitId: String,
+    modifier: Modifier = Modifier,
+    onAdLoadStarted: () -> Unit = {},
+    onAdLoaded: (BannerAd) -> Unit = {},
+    onAdFailedToLoad: (LoadAdError) -> Unit = {}
+) {
+    AdaptiveAdContainerContent(
+        adUnitId = adUnitId,
+        state = rememberAdContainerState(),
+        modifier = modifier,
+        adLoadCallback = object : AdLoadCallback<BannerAd> {
+            override fun onAdLoaded(ad: BannerAd) = onAdLoaded(ad)
+
+            override fun onAdFailedToLoad(adError: LoadAdError) = onAdFailedToLoad(adError)
+        },
+        onAdLoadStarted = onAdLoadStarted
+    )
+}
+
+@Composable
+private fun rememberBannerAdRequest(adUnitId: String, adSize: AdSize): BannerAdRequest =
+    remember(adUnitId, adSize) {
+        BannerAdRequest.Builder(adUnitId, adSize).build()
+    }
+
+/**
+ * Loads and displays a controllable large anchored adaptive banner using the available Compose
+ * width. The banner reloads when its calculated size or [adUnitId] changes.
+ *
+ * @param adUnitId the banner ad unit ID.
+ * @param state the observable state and reload control for this container.
+ * @param modifier the modifier applied to the full-width banner container.
+ * @param adLoadCallback receives the initial banner load result.
+ * @param adEventCallback receives click, impression, paid, app, and full-screen events.
+ * @param adRefreshCallback receives automatic banner refresh results.
+ */
+@Composable
+fun AdaptiveAdContainer(
+    adUnitId: String,
+    state: AdContainerState,
+    modifier: Modifier = Modifier,
+    adLoadCallback: AdLoadCallback<BannerAd>? = null,
+    adEventCallback: BannerAdEventCallback? = null,
+    adRefreshCallback: BannerAdRefreshCallback? = null
+) {
+    AdaptiveAdContainerContent(
+        adUnitId = adUnitId,
+        state = state,
+        modifier = modifier,
+        onAdLoadStarted = {},
+        adLoadCallback = adLoadCallback,
+        adEventCallback = adEventCallback,
+        adRefreshCallback = adRefreshCallback
+    )
+}
+
+@Composable
+private fun AdaptiveAdContainerContent(
+    adUnitId: String,
+    state: AdContainerState,
+    modifier: Modifier,
+    onAdLoadStarted: () -> Unit,
+    adLoadCallback: AdLoadCallback<BannerAd>?,
+    adEventCallback: BannerAdEventCallback? = null,
+    adRefreshCallback: BannerAdRefreshCallback? = null
+) {
+    val context = LocalContext.current
+    val density = LocalDensity.current
+    val windowInfo = LocalWindowInfo.current
+
+    BoxWithConstraints(modifier = modifier) {
+        val windowSize = windowInfo.containerSize
+        val windowWidthDp = with(density) {
+            windowSize.width.toDp().value.toInt()
+        }.coerceAtLeast(1)
+        val availableWidthDp = maxWidth.value
+            .takeIf { it.isFinite() && it > 0f }
+            ?.toInt()
+            ?: windowWidthDp
+        val adSize = remember(context, availableWidthDp, windowSize, density) {
+            AdSize.getLargeAnchoredAdaptiveBannerAdSize(context, availableWidthDp)
+        }
+
+        AdContainerHost(
+            adRequest = rememberBannerAdRequest(adUnitId, adSize),
+            state = state,
+            modifier = Modifier.fillMaxWidth(),
+            onAdLoadStarted = onAdLoadStarted,
+            adLoadCallback = adLoadCallback,
+            adEventCallback = adEventCallback,
+            adRefreshCallback = adRefreshCallback
+        )
+    }
+}

--- a/acv-compose/src/main/java/com/lazygeniouz/acv/compose/AdaptiveAdContainer.kt
+++ b/acv-compose/src/main/java/com/lazygeniouz/acv/compose/AdaptiveAdContainer.kt
@@ -110,7 +110,7 @@ private fun AdaptiveAdContainerContent(
             .takeIf { it.isFinite() && it > 0f }
             ?.toInt()
             ?: windowWidthDp
-        val adSize = remember(context, availableWidthDp, windowSize, density) {
+        val adSize = remember(context, availableWidthDp) {
             AdSize.getLargeAnchoredAdaptiveBannerAdSize(context, availableWidthDp)
         }
 

--- a/acv/src/main/java/com/lazygeniouz/acv/AdContainerView.kt
+++ b/acv/src/main/java/com/lazygeniouz/acv/AdContainerView.kt
@@ -176,7 +176,10 @@ class AdContainerView @JvmOverloads constructor(
                     if (newAdView === adView && activeLoadCallback === this) {
                         val currentBanner = adView.getBannerAd()
                         isAdLoaded = currentBanner != null && currentBanner === activeBannerAd
-                        if (!isAdLoaded) activeBannerAd = null
+                        if (!isAdLoaded) {
+                            activeBannerAd?.destroy()
+                            activeBannerAd = null
+                        }
                         adView.visibility = if (isAdLoaded) View.VISIBLE else View.GONE
                         if (pendingAdRequest == null) isAdLoading = false
                         logDebug("Banner load failed (${adError.code}): ${adError.message}")

--- a/acv/src/main/java/com/lazygeniouz/acv/AdContainerView.kt
+++ b/acv/src/main/java/com/lazygeniouz/acv/AdContainerView.kt
@@ -155,7 +155,9 @@ class AdContainerView @JvmOverloads constructor(
             override fun onAdLoaded(ad: BannerAd) {
                 runOnMainThread {
                     if (newAdView === adView && activeLoadCallback === this) {
+                        val previousAd = activeBannerAd
                         activeBannerAd = ad
+                        if (previousAd !== ad) previousAd?.destroy()
                         attachAdCallbacks(adView, ad)
                         isAdLoaded = true
                         adView.visibility = View.VISIBLE

--- a/acv/src/main/java/com/lazygeniouz/acv/AdContainerView.kt
+++ b/acv/src/main/java/com/lazygeniouz/acv/AdContainerView.kt
@@ -42,9 +42,13 @@ class AdContainerView @JvmOverloads constructor(
     private val hostLifecycleObserver = HostLifecycleObserver()
     private var observedLifecycle: Lifecycle? = null
     private var autoLoadPending = false
+    private var activeLoadCallback: AdLoadCallback<BannerAd>? = null
+    private var activeBannerAd: BannerAd? = null
+    private var pendingAdRequest: BannerAdRequest? = null
 
     /**
-     * Loads a banner with the configured ad unit and size.
+     * Loads a banner with the configured ad unit and size. Subsequent requests reuse the current
+     * [AdView]. If a load is already active, only the latest pending request is retained.
      * A skipped request reports [LoadAdError.ErrorCode.CANCELLED] and leaves the current banner
      * and request configuration unchanged.
      *
@@ -68,8 +72,9 @@ class AdContainerView @JvmOverloads constructor(
     )
 
     /**
-     * Loads a customized Next-Gen [BannerAdRequest]. The request's ad unit ID and
-     * ad size become this container's current values.
+     * Loads a customized Next-Gen [BannerAdRequest], reusing the current [AdView] for subsequent
+     * requests. If a load is already active, only the latest pending request is retained. The
+     * request's ad unit ID and ad size become this container's current values.
      * A skipped request reports [LoadAdError.ErrorCode.CANCELLED] and leaves the current banner
      * and request configuration unchanged.
      *
@@ -113,13 +118,27 @@ class AdContainerView @JvmOverloads constructor(
         adUnitId = adRequest.adUnitId
         adSize = adRequest.adSize
 
-        destroyAd()
-        isAdLoading = true
-
-        val adView = AdView(context).also {
-            it.visibility = View.GONE
-            it.background = transparent
+        val adView = newAdView ?: createAdView()
+        if (isAdLoading) {
+            pendingAdRequest = adRequest
+            logDebug("Queued the latest banner request until the current load finishes.")
+            return
         }
+
+        startAdLoad(adView, adRequest)
+    }
+
+    private fun startAdLoad(adView: AdView, adRequest: BannerAdRequest) {
+        isAdLoading = true
+        val callback = createLoadCallback(adView)
+        activeLoadCallback = callback
+        logDebug("Loading banner ($adSize).")
+        adView.loadAd(adRequest, callback)
+    }
+
+    private fun createAdView(): AdView = AdView(context).also { adView ->
+        adView.visibility = View.GONE
+        adView.background = transparent
         newAdView = adView
 
         val layoutParams = LayoutParams(
@@ -129,21 +148,21 @@ class AdContainerView @JvmOverloads constructor(
             addRule(CENTER_IN_PARENT)
         }
         addView(adView, layoutParams)
-        logDebug("Loading banner ($adSize).")
-        adView.loadAd(adRequest, createLoadCallback(adView))
     }
 
     private fun createLoadCallback(adView: AdView): AdLoadCallback<BannerAd> =
         object : AdLoadCallback<BannerAd> {
             override fun onAdLoaded(ad: BannerAd) {
-                attachAdCallbacks(adView, ad)
                 runOnMainThread {
-                    if (newAdView === adView) {
-                        isAdLoading = false
+                    if (newAdView === adView && activeLoadCallback === this) {
+                        activeBannerAd = ad
+                        attachAdCallbacks(adView, ad)
                         isAdLoaded = true
                         adView.visibility = View.VISIBLE
+                        if (pendingAdRequest == null) isAdLoading = false
                         logDebug("Banner loaded.")
                         loadCallback?.onAdLoaded(ad)
+                        loadPendingRequest(adView, this)
                     } else {
                         ad.destroy()
                     }
@@ -152,68 +171,87 @@ class AdContainerView @JvmOverloads constructor(
 
             override fun onAdFailedToLoad(adError: LoadAdError) {
                 runOnMainThread {
-                    if (newAdView === adView) {
-                        isAdLoading = false
-                        isAdLoaded = false
-                        adView.visibility = View.GONE
+                    if (newAdView === adView && activeLoadCallback === this) {
+                        val currentBanner = adView.getBannerAd()
+                        isAdLoaded = currentBanner != null && currentBanner === activeBannerAd
+                        if (!isAdLoaded) activeBannerAd = null
+                        adView.visibility = if (isAdLoaded) View.VISIBLE else View.GONE
+                        if (pendingAdRequest == null) isAdLoading = false
                         logDebug("Banner load failed (${adError.code}): ${adError.message}")
                         loadCallback?.onAdFailedToLoad(adError)
+                        loadPendingRequest(adView, this)
                     }
                 }
             }
         }
 
+    private fun loadPendingRequest(
+        adView: AdView,
+        completedCallback: AdLoadCallback<BannerAd>
+    ) {
+        if (newAdView !== adView || activeLoadCallback !== completedCallback) return
+
+        val request = pendingAdRequest ?: return
+        pendingAdRequest = null
+        startAdLoad(adView, request)
+    }
+
     private fun attachAdCallbacks(adView: AdView, ad: BannerAd) {
         ad.adEventCallback = object : BannerAdEventCallback {
-            override fun onAdClicked() = dispatchFor(adView) {
+            override fun onAdClicked() = dispatchFor(adView, ad) {
                 eventCallback?.onAdClicked()
             }
 
-            override fun onAdImpression() = dispatchFor(adView) {
+            override fun onAdImpression() = dispatchFor(adView, ad) {
                 eventCallback?.onAdImpression()
             }
 
-            override fun onAdPaid(value: AdValue) = dispatchFor(adView) {
+            override fun onAdPaid(value: AdValue) = dispatchFor(adView, ad) {
                 eventCallback?.onAdPaid(value)
             }
 
-            override fun onAdShowedFullScreenContent() = dispatchFor(adView) {
+            override fun onAdShowedFullScreenContent() = dispatchFor(adView, ad) {
                 eventCallback?.onAdShowedFullScreenContent()
             }
 
-            override fun onAdDismissedFullScreenContent() = dispatchFor(adView) {
+            override fun onAdDismissedFullScreenContent() = dispatchFor(adView, ad) {
                 eventCallback?.onAdDismissedFullScreenContent()
             }
 
             override fun onAdFailedToShowFullScreenContent(
                 fullScreenContentError: FullScreenContentError
-            ) = dispatchFor(adView) {
+            ) = dispatchFor(adView, ad) {
                 eventCallback?.onAdFailedToShowFullScreenContent(fullScreenContentError)
             }
 
-            override fun onAppEvent(name: String, data: String?) = dispatchFor(adView) {
+            override fun onAppEvent(name: String, data: String?) = dispatchFor(adView, ad) {
                 eventCallback?.onAppEvent(name, data)
             }
         }
 
         ad.bannerAdRefreshCallback = object : BannerAdRefreshCallback {
-            override fun onAdRefreshed() = dispatchFor(adView) {
+            override fun onAdRefreshed() = dispatchFor(adView, ad) {
                 isAdLoaded = true
                 adView.visibility = View.VISIBLE
                 logDebug("Banner refreshed.")
                 refreshCallback?.onAdRefreshed()
             }
 
-            override fun onAdFailedToRefresh(adError: LoadAdError) = dispatchFor(adView) {
+            override fun onAdFailedToRefresh(adError: LoadAdError) = dispatchFor(adView, ad) {
                 logDebug("Banner refresh failed (${adError.code}): ${adError.message}")
                 refreshCallback?.onAdFailedToRefresh(adError)
             }
         }
     }
 
-    private fun dispatchFor(adView: AdView, action: () -> Unit) {
+    private fun dispatchFor(adView: AdView, ad: BannerAd, action: () -> Unit) {
         runOnMainThread {
-            if (newAdView === adView) action()
+            if (newAdView === adView &&
+                activeBannerAd === ad &&
+                adView.getBannerAd() === ad
+            ) {
+                action()
+            }
         }
     }
 
@@ -245,6 +283,9 @@ class AdContainerView @JvmOverloads constructor(
     @MainThread
     fun destroyAd() {
         autoLoadPending = false
+        activeLoadCallback = null
+        activeBannerAd = null
+        pendingAdRequest = null
         newAdView?.destroy()
         newAdView = null
         isAdLoading = false

--- a/acv/src/main/java/com/lazygeniouz/acv/base/BaseAd.kt
+++ b/acv/src/main/java/com/lazygeniouz/acv/base/BaseAd.kt
@@ -84,10 +84,10 @@ open class BaseAd @JvmOverloads constructor(
      * Replaces the callback that receives the initial banner load result.
      * Callbacks registered through this view are delivered on the main thread.
      *
-     * @param callback the load callback to receive.
+     * @param callback the load callback to receive, or null to clear it.
      */
     @MainThread
-    fun setAdLoadCallback(callback: AdLoadCallback<BannerAd>) {
+    fun setAdLoadCallback(callback: AdLoadCallback<BannerAd>?) {
         loadCallback = callback
     }
 
@@ -102,10 +102,10 @@ open class BaseAd @JvmOverloads constructor(
      * events.
      * Callbacks registered through this view are delivered on the main thread.
      *
-     * @param callback the event callback to receive.
+     * @param callback the event callback to receive, or null to clear it.
      */
     @MainThread
-    fun setAdEventCallback(callback: BannerAdEventCallback) {
+    fun setAdEventCallback(callback: BannerAdEventCallback?) {
         eventCallback = callback
     }
 
@@ -119,10 +119,10 @@ open class BaseAd @JvmOverloads constructor(
      * Replaces the callback that receives automatic banner refresh results.
      * Callbacks registered through this view are delivered on the main thread.
      *
-     * @param callback the refresh callback to receive.
+     * @param callback the refresh callback to receive, or null to clear it.
      */
     @MainThread
-    fun setAdRefreshCallback(callback: BannerAdRefreshCallback) {
+    fun setAdRefreshCallback(callback: BannerAdRefreshCallback?) {
         refreshCallback = callback
     }
 

--- a/app/src/main/java/com/lazygeniouz/acv/example/BannerSample.kt
+++ b/app/src/main/java/com/lazygeniouz/acv/example/BannerSample.kt
@@ -1,6 +1,5 @@
 package com.lazygeniouz.acv.example
 
-import android.util.Log
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -33,14 +32,13 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
@@ -49,11 +47,11 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.google.android.libraries.ads.mobile.sdk.banner.AdSize
-import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
-import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
 import com.lazygeniouz.acv.AdContainerView
 import com.lazygeniouz.acv.compose.AdContainer
-import com.lazygeniouz.acv.compose.AdaptiveAdContainer
+import com.lazygeniouz.acv.compose.AdContainerLoadState
+import com.lazygeniouz.acv.compose.AdContainerState
+import com.lazygeniouz.acv.compose.rememberAdContainerState
 
 @Composable
 internal fun BannerSample(initializationResult: Result<Unit>?) {
@@ -62,13 +60,13 @@ internal fun BannerSample(initializationResult: Result<Unit>?) {
             .fillMaxSize()
             .safeDrawingPadding()
     ) {
+        val availableWidthDp = maxWidth.value.toInt().coerceAtLeast(1)
         val availableSizes = remember(maxWidth) {
             BannerSize.entries.filter { it.minimumWidthDp <= maxWidth.value }
         }
         var selectedSize by rememberSaveable { mutableStateOf(BannerSize.LARGE_ADAPTIVE) }
-        var reloadKey by rememberSaveable { mutableIntStateOf(0) }
-        var loadState by remember { mutableStateOf(LoadState.LOADING) }
-        var loadError by remember { mutableStateOf<String?>(null) }
+        val adContainerState = rememberAdContainerState()
+        val adLoadState = adContainerState.loadState
 
         LaunchedEffect(availableSizes) {
             if (selectedSize !in availableSizes) {
@@ -99,7 +97,8 @@ internal fun BannerSample(initializationResult: Result<Unit>?) {
 
                 val controlsEnabled = initializationResult?.isSuccess == true &&
                     selectedSize in availableSizes &&
-                    loadState != LoadState.LOADING
+                    adLoadState !is AdContainerLoadState.Idle &&
+                    adLoadState !is AdContainerLoadState.Loading
                 BannerSizeSelector(
                     sizes = availableSizes,
                     selectedSize = selectedSize,
@@ -111,11 +110,10 @@ internal fun BannerSample(initializationResult: Result<Unit>?) {
                 )
                 StatusRow(
                     initializationResult = initializationResult,
-                    loadState = loadState,
-                    loadError = loadError,
+                    adLoadState = adLoadState,
                     selectedSize = selectedSize,
                     reloadEnabled = controlsEnabled,
-                    onReload = { reloadKey++ },
+                    onReload = adContainerState::reload,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(top = 8.dp)
@@ -123,24 +121,11 @@ internal fun BannerSample(initializationResult: Result<Unit>?) {
             }
 
             if (initializationResult?.isSuccess == true && selectedSize in availableSizes) {
-                key(selectedSize, reloadKey) {
-                    Banner(
-                        size = selectedSize,
-                        onLoadStarted = {
-                            loadState = LoadState.LOADING
-                            loadError = null
-                        },
-                        onLoaded = {
-                            loadState = LoadState.LOADED
-                            loadError = null
-                        },
-                        onFailed = { error ->
-                            Log.w(TAG, "Banner failed to load: ${error.message}")
-                            loadState = LoadState.FAILED
-                            loadError = error.message.takeIf(String::isNotBlank)
-                        }
-                    )
-                }
+                Banner(
+                    size = selectedSize,
+                    state = adContainerState,
+                    availableWidthDp = availableWidthDp
+                )
             }
         }
     }
@@ -149,33 +134,29 @@ internal fun BannerSample(initializationResult: Result<Unit>?) {
 @Composable
 private fun Banner(
     size: BannerSize,
-    onLoadStarted: () -> Unit,
-    onLoaded: (BannerAd) -> Unit,
-    onFailed: (LoadAdError) -> Unit
+    state: AdContainerState,
+    availableWidthDp: Int
 ) {
+    val context = LocalContext.current
+    val adaptiveAdSize = remember(context, availableWidthDp) {
+        AdSize.getLargeAnchoredAdaptiveBannerAdSize(context, availableWidthDp)
+    }
+    val isAdaptive = size.adSize == null
+
     Box(
         modifier = Modifier.fillMaxWidth(),
         contentAlignment = Alignment.Center
     ) {
-        val fixedAdSize = size.adSize
-        if (fixedAdSize == null) {
-            AdaptiveAdContainer(
-                adUnitId = AdContainerView.ADAPTIVE_SIZE_TEST_AD_ID,
-                modifier = Modifier.fillMaxWidth(),
-                onAdLoadStarted = onLoadStarted,
-                onAdLoaded = onLoaded,
-                onAdFailedToLoad = onFailed
-            )
-        } else {
-            AdContainer(
-                adUnitId = AdContainerView.FIXED_SIZE_TEST_AD_ID,
-                adSize = fixedAdSize,
-                modifier = Modifier.wrapContentSize(),
-                onAdLoadStarted = onLoadStarted,
-                onAdLoaded = onLoaded,
-                onAdFailedToLoad = onFailed
-            )
-        }
+        AdContainer(
+            adUnitId = if (isAdaptive) {
+                AdContainerView.ADAPTIVE_SIZE_TEST_AD_ID
+            } else {
+                AdContainerView.FIXED_SIZE_TEST_AD_ID
+            },
+            adSize = size.adSize ?: adaptiveAdSize,
+            state = state,
+            modifier = if (isAdaptive) Modifier.fillMaxWidth() else Modifier.wrapContentSize()
+        )
     }
 }
 
@@ -230,23 +211,24 @@ private fun BannerSizeSelector(
 @Composable
 private fun StatusRow(
     initializationResult: Result<Unit>?,
-    loadState: LoadState,
-    loadError: String?,
+    adLoadState: AdContainerLoadState,
     selectedSize: BannerSize,
     reloadEnabled: Boolean,
     onReload: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val status = when {
-        initializationResult == null -> LoadState.LOADING
-        initializationResult.isFailure -> LoadState.FAILED
-        else -> loadState
+        initializationResult == null -> BannerStatus.LOADING
+        initializationResult.isFailure -> BannerStatus.FAILED
+        adLoadState is AdContainerLoadState.Loaded -> BannerStatus.LOADED
+        adLoadState is AdContainerLoadState.Failed -> BannerStatus.FAILED
+        else -> BannerStatus.LOADING
     }
     val title = when {
         initializationResult == null -> R.string.ad_status_initializing_title
         initializationResult.isFailure -> R.string.ad_status_initialization_failed_title
-        status == LoadState.LOADING -> R.string.ad_status_loading_title
-        status == LoadState.LOADED -> R.string.ad_status_loaded_title
+        status == BannerStatus.LOADING -> R.string.ad_status_loading_title
+        status == BannerStatus.LOADED -> R.string.ad_status_loaded_title
         else -> R.string.ad_status_load_failed_title
     }
     val sizeLabel = stringResource(selectedSize.label)
@@ -255,15 +237,19 @@ private fun StatusRow(
         initializationResult.isFailure -> initializationResult.exceptionOrNull()
             .errorDetail()
             ?: stringResource(R.string.ad_status_unknown_error)
-        status == LoadState.LOADING -> stringResource(
+        status == BannerStatus.LOADING -> stringResource(
             R.string.ad_status_loading_detail,
             sizeLabel
         )
-        status == LoadState.LOADED -> stringResource(
+        status == BannerStatus.LOADED -> stringResource(
             R.string.ad_status_loaded_detail,
             sizeLabel
         )
-        else -> loadError ?: stringResource(R.string.ad_status_unknown_error)
+        else -> (adLoadState as? AdContainerLoadState.Failed)
+            ?.error
+            ?.message
+            ?.takeIf(String::isNotBlank)
+            ?: stringResource(R.string.ad_status_unknown_error)
     }
 
     Row(
@@ -279,17 +265,17 @@ private fun StatusRow(
             contentAlignment = Alignment.Center
         ) {
             when (status) {
-                LoadState.LOADING -> CircularProgressIndicator(
+                BannerStatus.LOADING -> CircularProgressIndicator(
                     modifier = Modifier.size(24.dp),
                     strokeWidth = 3.dp
                 )
-                LoadState.LOADED -> Icon(
+                BannerStatus.LOADED -> Icon(
                     painter = painterResource(R.drawable.ic_check),
                     contentDescription = null,
                     modifier = Modifier.size(24.dp),
                     tint = MaterialTheme.colorScheme.primary
                 )
-                LoadState.FAILED -> Icon(
+                BannerStatus.FAILED -> Icon(
                     painter = painterResource(R.drawable.ic_error),
                     contentDescription = null,
                     modifier = Modifier.size(24.dp),
@@ -323,7 +309,7 @@ private fun StatusRow(
     }
 }
 
-private enum class LoadState {
+private enum class BannerStatus {
     LOADING,
     LOADED,
     FAILED
@@ -346,5 +332,3 @@ private fun Throwable?.errorDetail(): String? = this
     ?.let { it.cause ?: it }
     ?.message
     ?.takeIf(String::isNotBlank)
-
-private const val TAG = "AdContainerSample"

--- a/app/src/main/java/com/lazygeniouz/acv/example/BannerSample.kt
+++ b/app/src/main/java/com/lazygeniouz/acv/example/BannerSample.kt
@@ -39,6 +39,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
@@ -138,7 +140,9 @@ private fun Banner(
     availableWidthDp: Int
 ) {
     val context = LocalContext.current
-    val adaptiveAdSize = remember(context, availableWidthDp) {
+    val density = LocalDensity.current
+    val windowHeight = LocalWindowInfo.current.containerSize.height
+    val adaptiveAdSize = remember(context, availableWidthDp, windowHeight, density.density) {
         AdSize.getLargeAnchoredAdaptiveBannerAdSize(context, availableWidthDp)
     }
     val isAdaptive = size.adSize == null

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ signAllPublications=true
 
 GROUP=com.lazygeniouz
 POM_ARTIFACT_ID=acv
-VERSION_NAME=0.5.1
+VERSION_NAME=0.5.2
 
 POM_NAME=AdContainerView
 POM_DESCRIPTION=A lifecycle-aware banner ad container for the Google Mobile Ads Next-Gen SDK.


### PR DESCRIPTION
## Summary

- add observable Compose banner state with reload and typed callbacks
- retain the existing container and SDK `AdView` across reloads and request changes
- update the sample and README, and prepare version 0.5.2

## Validation

- `./gradlew check :acv:assembleRelease :acv-compose:assembleRelease :app:assembleDebug`
- adversarial review completed with no remaining findings